### PR TITLE
Fix minor spelling error in the readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ puts [{"c" => [2, 1]}, ["b", "a"]].deep_sort_by {|obj| obj.to_s}
 
 ### Deep Merging
 
-The deepsort gem also includes deep merging capabilities. This concatinates arrays and merges hashes in large nested structures. To add deep merging functionality to arrays and hashes, include it in your project like so:
+The deepsort gem also includes deep merging capabilities. This concatenates arrays and merges hashes in large nested structures. To add deep merging functionality to arrays and hashes, include it in your project like so:
 ```ruby
 require "deepmerge"
 ```


### PR DESCRIPTION
I noticed the mistake and thought I'd contribute a quick fix,
(definitely not as a procrastination activity while I should be
doing something else..)