### PR TITLE
add missing coverage and shiny badge

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       minitest (>= 5.0.0, < 5.12.0)
     minitest (5.11.3)
     rake (12.3.2)
-    single_cov (1.3.1)
+    single_cov (1.3.2)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # deepsort
 
-[![Gem Version](https://badge.fury.io/rb/deepsort.svg)](https://badge.fury.io/rb/deepsort) [![Build Status](https://travis-ci.org/mcrossen/deepsort.svg?branch=master)](https://travis-ci.org/mcrossen/deepsort)
+[![Gem Version](https://badge.fury.io/rb/deepsort.svg)](https://badge.fury.io/rb/deepsort) [![Build Status](https://travis-ci.org/mcrossen/deepsort.svg?branch=master)](https://travis-ci.org/mcrossen/deepsort) [![Coverage](https://img.shields.io/badge/coverage-100%25-success.svg)](https://github.com/grosser/single_cov)
 
 'deepsort' is a ruby gem that adds the methods you've always wanted to arrays and hashes. The next time you need to sort or merge an array inside of a hash inside of an array, deepsort makes that as easy as calling .deep_sort or .deep_merge on the object.
 

--- a/lib/deepmerge.rb
+++ b/lib/deepmerge.rb
@@ -21,7 +21,7 @@ module DeepMerge
   # inject this method into the Hash class to add deep merge functionality to Hashes
   module DeepMergeHash
     def deep_merge(other)
-      merge(other) do |key, oldval, newval|
+      merge(other) do |_key, oldval, newval|
         if oldval.respond_to? :deep_merge
           oldval.deep_merge(newval)
         else
@@ -31,7 +31,7 @@ module DeepMerge
     end
 
     def deep_merge!(other)
-      merge!(other) do |key, oldval, newval|
+      merge!(other) do |_key, oldval, newval|
         if oldval.respond_to? :deep_merge!
           oldval.deep_merge!(newval)
         else

--- a/test/test_deepmerge.rb
+++ b/test/test_deepmerge.rb
@@ -1,10 +1,10 @@
 require_relative "helper"
 require "deepmerge"
 
-SingleCov.covered! file: "lib/deepmerge.rb", uncovered:2
+SingleCov.covered!
 
-# much of the assertions are compared by string. this is because hash comparisons don't care about order - string comparisons do
-class TestDeepMerge < Minitest::Test
+# most assertions compare by string because hashes don't care about order
+describe DeepMerge do
   def test_array_shallow_merge
     vector = [1]
     assert_equal([1, 2], vector.deep_merge([2]))
@@ -43,5 +43,10 @@ class TestDeepMerge < Minitest::Test
     assert_equal({a:[1, {b:2}], c:{d:[3,4]}}, vector)
     vector.deep_merge!({a:["b"], c:{d:[5], e:"hello"}})
     assert_equal({a:[1, {b:2}, "b"], c:{d:[3,4,5], e:"hello"}}, vector)
+  end
+
+  it "overrides on collision" do
+    {a: 1}.deep_merge(a: 2).must_equal a: 2
+    {a: 1}.deep_merge!(a: 2).must_equal a: 2
   end
 end

--- a/test/test_deepsort.rb
+++ b/test/test_deepsort.rb
@@ -1,7 +1,7 @@
 require_relative "helper"
 require "deepsort"
 
-SingleCov.covered! file: "lib/deepsort.rb"
+SingleCov.covered!
 
 # much of the assertions are compared by string. this is because hash comparisons don't care about order - string comparisons do
 describe DeepSort do


### PR DESCRIPTION

<img width="566" alt="Screen Shot 2019-05-18 at 7 05 31 PM" src="https://user-images.githubusercontent.com/11367/57976888-f0e7e100-799f-11e9-9be2-f64d3768a3c8.png">


I added a patch to single_cov to support test_ prefix so we no longer need the ugly `file:` either

@mcrossen 