### PR TITLE
Skip hashs or arrays sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ puts [{"c" => [2, 1]}, ["b", "a"]].deep_sort_by {|obj| obj.to_s}
 # => [["a", "b"], {"c" => [1, 2]}]
 ```
 
+Skip arrays or hashs sorting.
+```ruby
+require "deepsort"
+
+puts {"b" => [2, 1], "a" => [4, 3]}.deep_sort(array: false)
+# => {"a" => [4, 3], "b" => [2, 1]}
+
+puts {"b" => [2, 1], "a" => [4, 3]}.deep_sort(hash: false)
+# => {"b" => [1, 2], "a" => [3, 4]}
+```
+
 ### Deep Merging
 
 The deepsort gem also includes deep merging capabilities. This concatenates arrays and merges hashes in large nested structures. To add deep merging functionality to arrays and hashes, include it in your project like so:

--- a/lib/deepsort.rb
+++ b/lib/deepsort.rb
@@ -16,77 +16,80 @@
 module DeepSort
   # inject this method into the Array class to add deep sort functionality to Arrays
   module DeepSortArray
-    def deep_sort
-      deep_sort_by { |obj| obj }
+    def deep_sort(options = {})
+      deep_sort_by(options) { |obj| obj }
     end
 
-    def deep_sort!
-      deep_sort_by! { |obj| obj }
+    def deep_sort!(options = {})
+      deep_sort_by!(options) { |obj| obj }
     end
 
-    def deep_sort_by(&block)
-      self.map do |value|
-        if value.respond_to? :deep_sort_by
-          value.deep_sort_by(&block)
+    def deep_sort_by(options = {}, &block)
+      array = self.map do |value|
+        if value.respond_to?(:deep_sort_by)
+          value.deep_sort_by(options, &block)
         else
           value
         end
-      end.sort_by(&block)
+      end
+      options[:array] == false ? array : array.sort_by(&block)
     end
 
-    def deep_sort_by!(&block)
-      self.map! do |value|
-        if value.respond_to? :deep_sort_by!
-          value.deep_sort_by!(&block)
+    def deep_sort_by!(options = {}, &block)
+      array = self.map! do |value|
+        if value.respond_to?(:deep_sort_by!)
+          value.deep_sort_by!(options, &block)
         else
           value
         end
-      end.sort_by!(&block)
+      end
+      options[:array] == false ? array : array.sort_by!(&block)
     end
   end
 
   # inject this method into the Hash class to add deep sort functionality to Hashes
   module DeepSortHash
-    def deep_sort
-      deep_sort_by { |obj| obj }
+    def deep_sort(options = {})
+      deep_sort_by(options) { |obj| obj }
     end
 
-    def deep_sort!
-      deep_sort_by! { |obj| obj }
+    def deep_sort!(options = {})
+      deep_sort_by!(options) { |obj| obj }
     end
 
-    def deep_sort_by(&block)
-      Hash[self.map do |key, value|
-        [if key.respond_to? :deep_sort_by
-          key.deep_sort_by(&block)
+    def deep_sort_by(options = {}, &block)
+      hash = self.map do |key, value|
+        [if key.respond_to?(:deep_sort_by)
+          key.deep_sort_by(options, &block)
         else
           key
         end,
 
-        if value.respond_to? :deep_sort_by
-          value.deep_sort_by(&block)
+        if value.respond_to?(:deep_sort_by)
+          value.deep_sort_by(options, &block)
         else
           value
         end]
+      end
 
-      end.sort_by(&block)]
+      Hash[options[:hash] == false ? hash : hash.sort_by(&block)]
     end
 
-    def deep_sort_by!(&block)
-      replace(Hash[self.map do |key, value|
-        [if key.respond_to? :deep_sort_by!
-          key.deep_sort_by!(&block)
+    def deep_sort_by!(options = {}, &block)
+      hash = self.map do |key, value|
+        [if key.respond_to?(:deep_sort_by!)
+          key.deep_sort_by!(options, &block)
         else
           key
         end,
 
-        if value.respond_to? :deep_sort_by!
-          value.deep_sort_by!(&block)
+        if value.respond_to?(:deep_sort_by!)
+          value.deep_sort_by!(options, &block)
         else
           value
         end]
-
-      end.sort_by!(&block)])
+      end
+      replace(Hash[options[:hash] == false ? hash : hash.sort_by!(&block)])
     end
 
     # comparison for hashes is ill-defined. this performs array or string comparison if the normal comparison fails.
@@ -101,9 +104,9 @@ Hash.send(:include, DeepSort::DeepSortHash)
 
 # and if you don't like calling member methods on objects, these two functions do it for you.
 # if the object cannot be deep sorted, it will simply return the sorted object or the object itself if sorting isn't available.
-def deep_sort(obj)
+def deep_sort(obj, options = {})
   if obj.respond_to? :deep_sort
-    obj.deep_sort
+    obj.deep_sort(options)
   elsif obj.respond_to? :sort
     obj.sort
   else
@@ -112,9 +115,9 @@ def deep_sort(obj)
 end
 
 # similar to the deep_sort method, but performs the deep sort in place
-def deep_sort!(obj)
+def deep_sort!(obj, options = {})
   if obj.respond_to? :deep_sort!
-    obj.deep_sort!
+    obj.deep_sort!(options)
   elsif obj.respond_to? :sort!
     obj.sort!
   else

--- a/test/test_deepsort.rb
+++ b/test/test_deepsort.rb
@@ -59,6 +59,29 @@ describe DeepSort do
     assert_equal(sorted.to_s, vector.to_s)
   end
 
+  def test_skip
+    initial_hashs  = {1=>2, 9=>[10, 12, 11], 3=>{6=>[8, 7], 4=>5}}
+    initial_arrays = {1=>2, 9=>[10, 12, 11], 3=>{6=>[8, 7], 4=>5}}
+    sorted_hashs   = {1=>2, 3=>{4=>5, 6=>[8, 7]}, 9=>[10, 12, 11]}
+    sorted_arrays  = {1=>2, 9=>[10, 11, 12], 3=>{6=>[7, 8], 4=>5}}
+
+    vector = initial_hashs
+    assert_equal(sorted_hashs.to_s, vector.deep_sort(array: false).to_s)
+    # ensure it didn't sort in place
+    assert_equal(initial_hashs.to_s, vector.to_s)
+    # now sort in place and vector
+    vector.deep_sort!(array: false)
+    assert_equal(sorted_hashs.to_s, vector.to_s)
+
+    vector = initial_arrays
+    assert_equal(sorted_arrays.to_s, vector.deep_sort(hash: false).to_s)
+    # ensure it didn't sort in place
+    assert_equal(initial_arrays.to_s, vector.to_s)
+    # now sort in place and vector
+    vector.deep_sort!(hash: false)
+    assert_equal(sorted_arrays.to_s, vector.to_s)
+  end
+
   def test_non_fixnum
     vector1 = {"d"=>"e", "a"=>["c", "b"]}
     vector2 = [["d", "c"], ["a", "b"]]
@@ -114,7 +137,7 @@ describe DeepSort do
     end
   end
 
-  describe "Object#deep_sort" do
+  describe "Object#deep_sort!" do
     it "sorts deeply" do
       original = [["a"], ["b", "a"]]
       deep_sort!(original)


### PR DESCRIPTION
This PR allows disabling hashs or arrays sorting with the following syntax:
```ruby
require "deepsort"

puts {"b" => [2, 1], "a" => [4, 3]}.deep_sort(array: false)
# => {"a" => [4, 3], "b" => [2, 1]}

puts {"b" => [2, 1], "a" => [4, 3]}.deep_sort(hash: false)
# => {"b" => [1, 2], "a" => [3, 4]}
```
There's no breaking change.

My use case is that I'm looking for differences between complex hashs, but arrays order is meaningful so I only want to deepsort hashs.