### PR TITLE
Add 2.7 support for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
 - 2.4
 - 2.5
 - 2.6
+- 2.7
 before_install: ruby -e "File.write('Gemfile.lock', File.read('Gemfile.lock').split('BUNDLED WITH').first)"
 deploy:
   provider: rubygems


### PR DESCRIPTION
👋 
It looks like there are no deprecation warning or something like that when running the tests.
https://travis-ci.com/github/berkos/deepsort/jobs/323763098
